### PR TITLE
fix(raw-fcc): avoid showing compensated fcc as rawFcc when rawSoh is …

### DIFF
--- a/app/src/main/java/com/dijia1124/plusplusbattery/data/util/BattUtils.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/data/util/BattUtils.kt
@@ -148,6 +148,7 @@ fun calcRawFcc(
     designCapacity: Int
 ): Int {
     if (compensatedFcc == designCapacity) return 0
+    if (rawSoh == 0f) return 0
     val match = coeffList.find { it.first == vbatUv }
 
     return if (match != null) {


### PR DESCRIPTION
…unknown