### PR TITLE
Refactor/move logic into repo

### DIFF
--- a/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/BatteryInfoRepository.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/BatteryInfoRepository.kt
@@ -48,6 +48,14 @@ private const val BCC_VOLTAGE_0_INDEX = 6
 private const val BCC_VOLTAGE_1_INDEX = 11
 private const val BCC_CURRENT_INDEX = 8
 private const val CURRENT_FULL_IN_MA = 25
+private val OPLUS_TYPES = setOf(
+    BatteryInfoType.OPLUS_RM, BatteryInfoType.OPLUS_FCC,
+    BatteryInfoType.OPLUS_RAW_FCC, BatteryInfoType.OPLUS_SOH,
+    BatteryInfoType.OPLUS_RAW_SOH, BatteryInfoType.OPLUS_QMAX,
+    BatteryInfoType.OPLUS_VBAT_UV, BatteryInfoType.OPLUS_SN,
+    BatteryInfoType.OPLUS_MANU_DATE, BatteryInfoType.OPLUS_BATTERY_TYPE,
+    BatteryInfoType.OPLUS_DESIGN_CAPACITY
+)
 
 class BatteryInfoRepository(private val context: Context) {
     private val batteryManager get() =
@@ -449,14 +457,6 @@ class BatteryInfoRepository(private val context: Context) {
         return if (isRoot) {
             val infoList = (getBasicBatteryInfo() + getRootBatteryInfo() + readCustomEntries()).toMutableList()
             if (!showOplus) {
-                val OPLUS_TYPES = setOf(
-                    BatteryInfoType.OPLUS_RM, BatteryInfoType.OPLUS_FCC,
-                    BatteryInfoType.OPLUS_RAW_FCC, BatteryInfoType.OPLUS_SOH,
-                    BatteryInfoType.OPLUS_RAW_SOH, BatteryInfoType.OPLUS_QMAX,
-                    BatteryInfoType.OPLUS_VBAT_UV, BatteryInfoType.OPLUS_SN,
-                    BatteryInfoType.OPLUS_MANU_DATE, BatteryInfoType.OPLUS_BATTERY_TYPE,
-                    BatteryInfoType.OPLUS_DESIGN_CAPACITY
-                )
                 infoList.removeAll { it.type in OPLUS_TYPES }
             }
             infoList

--- a/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/BatteryInfoRepository.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/BatteryInfoRepository.kt
@@ -461,7 +461,10 @@ class BatteryInfoRepository(private val context: Context) {
             }
             infoList
         } else {
-            getBasicBatteryInfo() + getNonRootVoltCurrPwr()
+            val infoList = (getBasicBatteryInfo() + getNonRootVoltCurrPwr()).toMutableList()
+            val savedFcc = estimatedFccFlow.first()
+            infoList.add(getEstimatedFcc(savedFcc))
+            infoList
         }
     }
 }

--- a/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/BatteryInfoRepository.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/BatteryInfoRepository.kt
@@ -445,9 +445,21 @@ class BatteryInfoRepository(private val context: Context) {
         mergeAndSave(list)
     }
 
-    suspend fun getAvailableBatteryInfo(isRoot: Boolean): List<BatteryInfo> {
+    suspend fun getAvailableBatteryInfo(isRoot: Boolean, showOplus: Boolean): List<BatteryInfo> {
         return if (isRoot) {
-            getBasicBatteryInfo() + getRootBatteryInfo() + readCustomEntries()
+            val infoList = (getBasicBatteryInfo() + getRootBatteryInfo() + readCustomEntries()).toMutableList()
+            if (!showOplus) {
+                val OPLUS_TYPES = setOf(
+                    BatteryInfoType.OPLUS_RM, BatteryInfoType.OPLUS_FCC,
+                    BatteryInfoType.OPLUS_RAW_FCC, BatteryInfoType.OPLUS_SOH,
+                    BatteryInfoType.OPLUS_RAW_SOH, BatteryInfoType.OPLUS_QMAX,
+                    BatteryInfoType.OPLUS_VBAT_UV, BatteryInfoType.OPLUS_SN,
+                    BatteryInfoType.OPLUS_MANU_DATE, BatteryInfoType.OPLUS_BATTERY_TYPE,
+                    BatteryInfoType.OPLUS_DESIGN_CAPACITY
+                )
+                infoList.removeAll { it.type in OPLUS_TYPES }
+            }
+            infoList
         } else {
             getBasicBatteryInfo() + getNonRootVoltCurrPwr()
         }

--- a/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/BatteryInfoRepository.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/BatteryInfoRepository.kt
@@ -444,4 +444,12 @@ class BatteryInfoRepository(private val context: Context) {
         val list = Json.decodeFromString<List<CustomEntry>>(json)
         mergeAndSave(list)
     }
+
+    suspend fun getAvailableBatteryInfo(isRoot: Boolean): List<BatteryInfo> {
+        return if (isRoot) {
+            getBasicBatteryInfo() + getRootBatteryInfo() + readCustomEntries()
+        } else {
+            getBasicBatteryInfo() + getNonRootVoltCurrPwr()
+        }
+    }
 }

--- a/app/src/main/java/com/dijia1124/plusplusbattery/service/BatteryMonitorService.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/service/BatteryMonitorService.kt
@@ -132,9 +132,7 @@ class BatteryMonitorService : Service() {
 
     private suspend fun fetchBatteryStatus(): String = withContext(Dispatchers.IO) {
         val isRoot = prefsRepo.isRootModeFlow.first()
-        val allInfos =
-            if (isRoot) batteryRepo.getBasicBatteryInfo() + batteryRepo.getRootBatteryInfo() + batteryRepo.readCustomEntries()
-            else batteryRepo.getBasicBatteryInfo() + batteryRepo.getNonRootVoltCurrPwr()
+        val allInfos = batteryRepo.getAvailableBatteryInfo(isRoot)
         val visibleTypes = prefsRepo.visibleEntriesFlow.first()
         val filtered = if (visibleTypes.isEmpty()) {
             allInfos

--- a/app/src/main/java/com/dijia1124/plusplusbattery/service/BatteryMonitorService.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/service/BatteryMonitorService.kt
@@ -132,7 +132,8 @@ class BatteryMonitorService : Service() {
 
     private suspend fun fetchBatteryStatus(): String = withContext(Dispatchers.IO) {
         val isRoot = prefsRepo.isRootModeFlow.first()
-        val allInfos = batteryRepo.getAvailableBatteryInfo(isRoot)
+        val showOplus = prefsRepo.showOplusFields.first()
+        val allInfos = batteryRepo.getAvailableBatteryInfo(isRoot, showOplus)
         val visibleTypes = prefsRepo.visibleEntriesFlow.first()
         val filtered = if (visibleTypes.isEmpty()) {
             allInfos

--- a/app/src/main/java/com/dijia1124/plusplusbattery/service/FloatingWindowService.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/service/FloatingWindowService.kt
@@ -201,9 +201,7 @@ class FloatingWindowService : Service(), ViewModelStoreOwner, SavedStateRegistry
 
     private suspend fun fetchBatteryInfo(): String = withContext(Dispatchers.IO) {
         val isRoot = prefsRepo.isRootModeFlow.first()
-        val allInfos =
-            if (isRoot) batteryRepo.getBasicBatteryInfo() + batteryRepo.getRootBatteryInfo() + batteryRepo.readCustomEntries()
-            else batteryRepo.getBasicBatteryInfo() + batteryRepo.getNonRootVoltCurrPwr()
+        val allInfos = batteryRepo.getAvailableBatteryInfo(isRoot)
 
         val visibleTypes = prefsRepo.visibleEntriesFlow.first()
 

--- a/app/src/main/java/com/dijia1124/plusplusbattery/service/FloatingWindowService.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/service/FloatingWindowService.kt
@@ -201,7 +201,8 @@ class FloatingWindowService : Service(), ViewModelStoreOwner, SavedStateRegistry
 
     private suspend fun fetchBatteryInfo(): String = withContext(Dispatchers.IO) {
         val isRoot = prefsRepo.isRootModeFlow.first()
-        val allInfos = batteryRepo.getAvailableBatteryInfo(isRoot)
+        val showOplus = prefsRepo.showOplusFields.first()
+        val allInfos = batteryRepo.getAvailableBatteryInfo(isRoot, showOplus)
 
         val visibleTypes = prefsRepo.visibleEntriesFlow.first()
 

--- a/app/src/main/java/com/dijia1124/plusplusbattery/ui/screen/Dashboard.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/ui/screen/Dashboard.kt
@@ -1,8 +1,6 @@
 package com.dijia1124.plusplusbattery.ui.screen
 
 import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
 import android.net.Uri
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -370,17 +368,8 @@ fun DashBoardContent(hasRoot: Boolean, batteryInfoViewModel: BatteryInfoViewMode
     var coeffDialogText by remember { mutableStateOf(context.getString(R.string.unknown)) }
     val batteryInfoList = remember { mutableStateListOf<BatteryInfo>() }
     val lifecycleOwner = LocalLifecycleOwner.current
-    val showOplusFields by settingsViewModel.showOplusFields.collectAsState()
     val powerDataPoints = remember { mutableStateListOf<PowerDataPoint>() }
     var chartStartTime by remember { mutableLongStateOf(System.currentTimeMillis()) }
-    val OPLUS_TYPES = setOf(
-        BatteryInfoType.OPLUS_RM, BatteryInfoType.OPLUS_FCC,
-        BatteryInfoType.OPLUS_RAW_FCC, BatteryInfoType.OPLUS_SOH,
-        BatteryInfoType.OPLUS_RAW_SOH, BatteryInfoType.OPLUS_QMAX,
-        BatteryInfoType.OPLUS_VBAT_UV, BatteryInfoType.OPLUS_SN,
-        BatteryInfoType.OPLUS_MANU_DATE, BatteryInfoType.OPLUS_BATTERY_TYPE,
-        BatteryInfoType.OPLUS_DESIGN_CAPACITY
-    )
 
     LaunchedEffect(isRootMode, hasRoot, lifecycleOwner, isCelsius) {
         if (!hasRoot && isRootMode) {
@@ -395,11 +384,6 @@ fun DashBoardContent(hasRoot: Boolean, batteryInfoViewModel: BatteryInfoViewMode
 
                 while (true) {
                     val displayList = batteryInfoViewModel.getDisplayBatteryInfo().toMutableList()
-
-                    // filter out OPLUS types if showOplusFields is false
-                    if (isRootMode && !showOplusFields) {
-                        displayList.removeAll { it.type in OPLUS_TYPES }
-                    }
 
                     // Collect power data for chart
                     collectPowerDataForChart(displayList, powerDataPoints, chartStartTime)

--- a/app/src/main/java/com/dijia1124/plusplusbattery/ui/screen/Dashboard.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/ui/screen/Dashboard.kt
@@ -394,38 +394,18 @@ fun DashBoardContent(hasRoot: Boolean, batteryInfoViewModel: BatteryInfoViewMode
                 chartStartTime = System.currentTimeMillis()
 
                 while (true) {
-                    val basicList = batteryInfoViewModel.refreshBatteryInfo()
-                    val displayList = mutableListOf<BatteryInfo>().apply { addAll(basicList) }
+                    val displayList = batteryInfoViewModel.getDisplayBatteryInfo().toMutableList()
 
-                    val intent = context.registerReceiver(
-                        null,
-                        IntentFilter(Intent.ACTION_BATTERY_CHANGED)
-                    )
-
-                    intent?.let {
-                        if (isRootMode) {
-                            val rootList = batteryInfoViewModel.refreshBatteryInfoWithRoot()
-                            displayList.addAll(rootList)
-                            // add custom fields if root access is available
-                            val customList = batteryInfoViewModel.readCustomEntries()
-                            displayList.addAll(customList)
-                            // filter out OPLUS types if showOplusFields is false
-                            if (!showOplusFields) displayList.removeAll { it.type in OPLUS_TYPES }
-                        } else {
-                            // use system battery manager api if root access is not available
-                            val nonRootVCPList =
-                                batteryInfoViewModel.refreshNonRootVoltCurrPwr()
-                            displayList.addAll(nonRootVCPList)
-                            val fccInfo = batteryInfoViewModel.refreshEstimatedFcc()
-                            displayList.add(fccInfo)
-                        }
-
-                        // Collect power data for chart
-                        collectPowerDataForChart(displayList, powerDataPoints, chartStartTime)
-
-                        batteryInfoList.clear()
-                        batteryInfoList.addAll(displayList)
+                    // filter out OPLUS types if showOplusFields is false
+                    if (isRootMode && !showOplusFields) {
+                        displayList.removeAll { it.type in OPLUS_TYPES }
                     }
+
+                    // Collect power data for chart
+                    collectPowerDataForChart(displayList, powerDataPoints, chartStartTime)
+
+                    batteryInfoList.clear()
+                    batteryInfoList.addAll(displayList)
                     delay(refreshInterval.toLong())
                 }
             }

--- a/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryInfoViewModel.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryInfoViewModel.kt
@@ -89,11 +89,7 @@ class BatteryInfoViewModel(application: Application,
     suspend fun getDisplayBatteryInfo(): List<BatteryInfo> = withContext(Dispatchers.IO) {
         val isRoot = isRootMode.value
         val showOplus = showOplusFields.value
-        val infoList = batteryInfoRepository.getAvailableBatteryInfo(isRoot, showOplus).toMutableList()
-        if (!isRoot) {
-            infoList.add(batteryInfoRepository.getEstimatedFcc(savedEstimatedFcc.value))
-        }
-        return@withContext infoList
+        batteryInfoRepository.getAvailableBatteryInfo(isRoot, showOplus)
     }
 
     suspend fun refreshEstimatedFcc(): BatteryInfo =

--- a/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryInfoViewModel.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryInfoViewModel.kt
@@ -47,6 +47,9 @@ class BatteryInfoViewModel(application: Application,
         prefsRepo.setShowSwitchOnDashboard(show)
     }
 
+    val showOplusFields: StateFlow<Boolean> = prefsRepo.showOplusFields
+        .stateIn(viewModelScope, SharingStarted.Companion.Eagerly, true)
+
     val savedEstimatedFcc: StateFlow<String> = batteryInfoRepository.estimatedFccFlow
         .stateIn(
             viewModelScope,
@@ -85,7 +88,8 @@ class BatteryInfoViewModel(application: Application,
 
     suspend fun getDisplayBatteryInfo(): List<BatteryInfo> = withContext(Dispatchers.IO) {
         val isRoot = isRootMode.value
-        val infoList = batteryInfoRepository.getAvailableBatteryInfo(isRoot).toMutableList()
+        val showOplus = showOplusFields.value
+        val infoList = batteryInfoRepository.getAvailableBatteryInfo(isRoot, showOplus).toMutableList()
         if (!isRoot) {
             infoList.add(batteryInfoRepository.getEstimatedFcc(savedEstimatedFcc.value))
         }

--- a/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryInfoViewModel.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryInfoViewModel.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import android.os.BatteryManager
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.dijia1124.plusplusbattery.R
 import com.dijia1124.plusplusbattery.data.model.BatteryInfo
 import com.dijia1124.plusplusbattery.data.model.CustomEntry
 import com.dijia1124.plusplusbattery.data.repository.BatteryInfoRepository
@@ -50,13 +49,6 @@ class BatteryInfoViewModel(application: Application,
     val showOplusFields: StateFlow<Boolean> = prefsRepo.showOplusFields
         .stateIn(viewModelScope, SharingStarted.Companion.Eagerly, true)
 
-    val savedEstimatedFcc: StateFlow<String> = batteryInfoRepository.estimatedFccFlow
-        .stateIn(
-            viewModelScope,
-            SharingStarted.Companion.Eagerly,
-            getApplication<Application>().getString(R.string.estimating_full_charge_capacity)
-        )
-
     val isDualBatt: StateFlow<Boolean> = batteryInfoRepository.isDualBattFlow
         .stateIn(viewModelScope, SharingStarted.Companion.Eagerly, false)
 
@@ -91,11 +83,6 @@ class BatteryInfoViewModel(application: Application,
         val showOplus = showOplusFields.value
         batteryInfoRepository.getAvailableBatteryInfo(isRoot, showOplus)
     }
-
-    suspend fun refreshEstimatedFcc(): BatteryInfo =
-        withContext(Dispatchers.IO) {
-            batteryInfoRepository.getEstimatedFcc(savedEstimatedFcc.value)
-        }
 
     suspend fun saveCycleCount() {
         saveCycleCountToHistory(context, historyInfoRepository)

--- a/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryInfoViewModel.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryInfoViewModel.kt
@@ -83,23 +83,14 @@ class BatteryInfoViewModel(application: Application,
     suspend fun removeCustomEntry(path: String) =
         batteryInfoRepository.removeCustomEntry(path)
 
-    suspend fun readCustomEntries(): List<BatteryInfo> =
-        batteryInfoRepository.readCustomEntries()
-
-    suspend fun refreshBatteryInfo(): List<BatteryInfo> =
-        withContext(Dispatchers.IO) {
-            batteryInfoRepository.getBasicBatteryInfo()
+    suspend fun getDisplayBatteryInfo(): List<BatteryInfo> = withContext(Dispatchers.IO) {
+        val isRoot = isRootMode.value
+        val infoList = batteryInfoRepository.getAvailableBatteryInfo(isRoot).toMutableList()
+        if (!isRoot) {
+            infoList.add(batteryInfoRepository.getEstimatedFcc(savedEstimatedFcc.value))
         }
-
-    suspend fun refreshBatteryInfoWithRoot(): List<BatteryInfo> =
-        withContext(Dispatchers.IO) {
-            batteryInfoRepository.getRootBatteryInfo()
-        }
-
-    suspend fun refreshNonRootVoltCurrPwr(): List<BatteryInfo> =
-        withContext(Dispatchers.IO) {
-            batteryInfoRepository.getNonRootVoltCurrPwr()
-        }
+        return@withContext infoList
+    }
 
     suspend fun refreshEstimatedFcc(): BatteryInfo =
         withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryMonitorSettingsViewModel.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryMonitorSettingsViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -69,8 +70,9 @@ class BatteryMonitorSettingsViewModel(
 
     init {
         viewModelScope.launch {
-            prefsRepo.isRootModeFlow.collect { isRoot ->
-                val allInfos = batteryRepo.getAvailableBatteryInfo(isRoot)
+            combine(prefsRepo.isRootModeFlow, prefsRepo.showOplusFields) { isRoot, showOplus ->
+                batteryRepo.getAvailableBatteryInfo(isRoot, showOplus)
+            }.collect { allInfos ->
                 _availableEntries.value = allInfos.map { it.type }.distinct()
             }
         }

--- a/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryMonitorSettingsViewModel.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryMonitorSettingsViewModel.kt
@@ -70,11 +70,7 @@ class BatteryMonitorSettingsViewModel(
     init {
         viewModelScope.launch {
             prefsRepo.isRootModeFlow.collect { isRoot ->
-                val allInfos = if (isRoot) {
-                    batteryRepo.getBasicBatteryInfo() + batteryRepo.getRootBatteryInfo() + batteryRepo.readCustomEntries()
-                } else {
-                    batteryRepo.getBasicBatteryInfo() + batteryRepo.getNonRootVoltCurrPwr()
-                }
+                val allInfos = batteryRepo.getAvailableBatteryInfo(isRoot)
                 _availableEntries.value = allInfos.map { it.type }.distinct()
             }
         }


### PR DESCRIPTION
This pull request consolidates the business logic for fetching and filtering battery information into a
single, centralized location within the `BatteryInfoRepository`.

## Motivation

Previously, the logic for deciding which battery information to display was duplicated across multiple
parts of the application, including `Dashboard.kt`, `BatteryMonitorService.kt`, and `FloatingWindowService.kt`.
This duplication made the code difficult to maintain and created the risk of inconsistencies in the data
presented to the user.

The goal of this refactoring is to establish a single source of truth for battery data, improving code
quality, maintainability, and architectural consistency.

## Changes Included

This pull request includes the following key changes:

1.  **Centralized Logic in `BatteryInfoRepository`**:
    * A new `getAvailableBatteryInfo(isRoot: Boolean, showOplus: Boolean)` method has been introduced in
        `BatteryInfoRepository`.
    * This method now encapsulates all the rules for data retrieval, including:
        * Fetching the correct set of entries based on root status.
        * Filtering OPLUS-specific fields based on user preference.
        * Appending the estimated FCC for non-root users.

2.  **Updated Consumers**:
    * `BatteryMonitorService`, `FloatingWindowService`, `BatteryInfoViewModel`, and
        `BatteryMonitorSettingsViewModel` have all been updated to use the new, centralized
        `getAvailableBatteryInfo` method.
    * This ensures that all parts of the app (Dashboard, Notification, Floating Window) display a consistent
        set of information.

3.  **Simplified UI and ViewModels**:
    * The data-fetching and filtering logic has been removed from `Dashboard.kt`, significantly simplifying
        its `LaunchedEffect` block.
    * Redundant data-fetching methods were removed from `BatteryInfoViewModel`, making its role clearer.

By moving all data-related business logic to the repository layer, the application's architecture is now
cleaner, more robust, and easier to extend in the future.