### PR TITLE
fix(power-chart): use locale-aware number parsing for data

### DIFF
--- a/app/src/main/java/com/dijia1124/plusplusbattery/data/util/BattUtils.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/data/util/BattUtils.kt
@@ -44,10 +44,10 @@ fun getBoolString(boolVal: Boolean, context: Context): String = when(boolVal) {
 fun Double.formatClean(fractionDigits: Int = 2): String {
     return if (this % 1.0 == 0.0) {
         // hide decimal point for integer
-        "%d".format(this.toLong())
+        String.format(Locale.getDefault(), "%d", this.toLong())
     } else {
         // show decimal point for double
-        "%.${fractionDigits}f".format(this)
+        String.format(Locale.getDefault(), "%.${fractionDigits}f", this)
     }
 }
 
@@ -55,15 +55,16 @@ fun Double.formatWithUnit(unit: String, fractionDigits: Int = 2): String =
     "${this.formatClean(fractionDigits)} $unit"
 
 fun convertCelsiusToFahrenheit(celsius: Double): Double {
-    return String.format(Locale.US, "%.1f", celsius * 9 / 5 + 32).toDouble()
+    return celsius * 9 / 5 + 32
 }
 
 fun formatTemperature(temperature: Int, isCelsius: Boolean): String {
     val tempInCelsius = temperature / 10.0
     return if (isCelsius) {
-        "${tempInCelsius}°C"
+        String.format(Locale.getDefault(), "%.1f°C", tempInCelsius)
     } else {
-        "${convertCelsiusToFahrenheit(tempInCelsius)}°F"
+        val tempInFahrenheit = convertCelsiusToFahrenheit(tempInCelsius)
+        String.format(Locale.getDefault(), "%.1f°F", tempInFahrenheit)
     }
 }
 

--- a/app/src/main/java/com/dijia1124/plusplusbattery/ui/screen/Dashboard.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/ui/screen/Dashboard.kt
@@ -96,6 +96,7 @@ import com.dijia1124.plusplusbattery.ui.components.getListItemShape
 import com.dijia1124.plusplusbattery.ui.components.showRootDeniedToast
 import com.dijia1124.plusplusbattery.vm.SettingsViewModel
 import kotlinx.coroutines.launch
+import java.text.NumberFormat
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -859,8 +860,9 @@ private fun collectPowerDataForChart(
 
     powerInfo?.let { power ->
         try {
-            val powerValue = power.value.replace(Regex("[^-?0-9.]"), "").toFloatOrNull() ?: 0f
-            val tempValue = tempInfo?.value?.replace(Regex("[^-?0-9.]"), "")?.toFloatOrNull() ?: 0f
+            val nf = NumberFormat.getInstance()
+            val powerValue = nf.parse(power.value)?.toFloat() ?: 0f
+            val tempValue = tempInfo?.value?.let { nf.parse(it)?.toFloat() } ?: 0f
             val currentTime = System.currentTimeMillis()
 
             powerDataPoints.add(PowerDataPoint(


### PR DESCRIPTION
This pull request includes a comprehensive fix for how numbers are handled across the app, ensuring they are correctly parsed from strings and formatted for display according to the user's locale.
### What's Included:

This PR addresses number formatting and parsing issues on two fronts:

1.  **Correct Display Formatting:** The utility functions used for displaying numbers (like temperature and power) have been updated to be locale-aware. This fixes the issue values were always shown with a period (`.`) as the decimal separator. Now, they will be displayed with the correct character (e.g., a comma `,`) based on the user's region.

2.  **Correct Chart Parsing:** The logic that reads these values for the power chart has been updated to also be locale-aware. This fixes the critical bug where a displayed value like `"22,34 W"` was being parsed as `2234`, making the chart unhappy.

Together, these changes ensure a correct and consistent experience for all users, regardless of their language or region settings.

Closes #57 