### PR TITLE
chore: change working branch for sonarqube from main to dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: SonarQube
 on:
   push:
     branches:
-      - main
+      - dev
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
This pull request includes a change about changing the working directory for SonarQube Cloud code review.