### PR TITLE
refactor: integrate Hilt for dependency injection

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.serialization)
+    alias(libs.plugins.hilt)
 }
 
 android {
@@ -72,6 +73,8 @@ dependencies {
     implementation(libs.core)
     implementation(libs.io)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
     ksp(libs.androidx.room.compiler)
     testImplementation(libs.junit)
     testImplementation(libs.kotlin.test)

--- a/app/src/main/java/com/dijia1124/plusplusbattery/MainActivity.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -25,8 +26,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavController
 import com.dijia1124.plusplusbattery.ui.nav.NavRoute
 import com.dijia1124.plusplusbattery.ui.screen.About
@@ -44,80 +43,25 @@ import com.dijia1124.plusplusbattery.vm.FloatingWindowSettingsViewModel
 import com.dijia1124.plusplusbattery.vm.HistoryInfoViewModel
 import com.dijia1124.plusplusbattery.vm.SettingsViewModel
 import com.topjohnwu.superuser.Shell
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     // This list contains the top-level routes that will show the bottom navigation bar
     private val topLevelRoutes = listOf(
         "dashboard", "battery_monitor", "history", "settings"
     )
+    private val settingsViewModel: SettingsViewModel by viewModels()
+    private val battMonViewModel: BatteryMonitorSettingsViewModel by viewModels()
+    private val floatingWindowSettingsViewModel: FloatingWindowSettingsViewModel by viewModels()
+    private val batteryInfoViewModel: BatteryInfoViewModel by viewModels()
+    private val historyInfoViewModel: HistoryInfoViewModel by viewModels()
+    private val batteryLogViewModel: BatteryLogViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-
-        val settingsViewModel by lazy {
-            ViewModelProvider(
-                this,
-                object : ViewModelProvider.Factory {
-                    override fun <T : ViewModel> create(modelClass: Class<T>): T =
-                        SettingsViewModel(application) as T
-                }
-            )[SettingsViewModel::class.java]
-        }
-
-        val battMonViewModel by lazy{
-            ViewModelProvider(
-                this,
-                object : ViewModelProvider.Factory {
-                    override fun <T : ViewModel> create(modelClass: Class<T>): T =
-                        BatteryMonitorSettingsViewModel(application) as T
-                }
-            )[BatteryMonitorSettingsViewModel::class.java]
-        }
-
-        val floatingWindowSettingsViewModel by lazy {
-            ViewModelProvider(
-                this,
-                object : ViewModelProvider.Factory {
-                    override fun <T : ViewModel> create(modelClass: Class<T>): T =
-                        FloatingWindowSettingsViewModel(application) as T
-                }
-            )[FloatingWindowSettingsViewModel::class.java]
-        }
-
-        val batteryInfoViewModel by lazy {
-            ViewModelProvider(
-                this,
-                object : ViewModelProvider.Factory {
-                    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                        return BatteryInfoViewModel(application) as T
-                    }
-                }
-            )[BatteryInfoViewModel::class.java]
-        }
-
-        val historyInfoViewModel by lazy {
-            ViewModelProvider(
-                this,
-                object : ViewModelProvider.Factory {
-                    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                        return HistoryInfoViewModel(application) as T
-                    }
-                }
-            )[HistoryInfoViewModel::class.java]
-        }
-
-        val batteryLogViewModel by lazy {
-            ViewModelProvider(
-                this,
-                object : ViewModelProvider.Factory {
-                    override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                        return BatteryLogViewModel(application) as T
-                    }
-                }
-            )[BatteryLogViewModel::class.java]
-        }
 
         setContent {
             //        Shell.enableVerboseLogging = true  // Enable verbose logging for debugging

--- a/app/src/main/java/com/dijia1124/plusplusbattery/MainApplication.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/MainApplication.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.dijia1124.plusplusbattery.data.repository.PrefsRepository
+import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -13,6 +14,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
+@HiltAndroidApp
 class MainApplication : Application() {
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)

--- a/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/BatteryInfoRepository.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/BatteryInfoRepository.kt
@@ -31,6 +31,7 @@ import com.dijia1124.plusplusbattery.data.util.readBatteryInfo
 import com.dijia1124.plusplusbattery.data.util.readBatteryLogMap
 import com.dijia1124.plusplusbattery.data.util.readTermCoeff
 import com.dijia1124.plusplusbattery.data.util.safeRootReadInt
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -41,6 +42,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.io.IOException
+import javax.inject.Inject
 import kotlin.collections.map
 import kotlin.math.pow
 
@@ -57,7 +59,9 @@ private val OPLUS_TYPES = setOf(
     BatteryInfoType.OPLUS_DESIGN_CAPACITY
 )
 
-class BatteryInfoRepository(private val context: Context) {
+class BatteryInfoRepository @Inject constructor(
+    @param:ApplicationContext private val context: Context
+) {
     private val batteryManager get() =
         context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
     private val settings by lazy { context.dataStore }

--- a/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/BatteryLogRepository.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/BatteryLogRepository.kt
@@ -10,8 +10,9 @@ import com.dijia1124.plusplusbattery.data.parser.XiaomiLogParser
 import com.topjohnwu.superuser.Shell
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
-class BatteryLogRepository {
+class BatteryLogRepository @Inject constructor() {
     private val oplusParsers = listOf(OPlusLogParser(), FallbackLogParser())
 
     private val allParsers: Map<String, List<LogParser>> = mapOf(

--- a/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/HistoryInfoRepository.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/HistoryInfoRepository.kt
@@ -5,8 +5,11 @@ import com.dijia1124.plusplusbattery.data.local.HistoryInfoDao
 import com.dijia1124.plusplusbattery.data.local.HistoryInfoDatabase
 import com.dijia1124.plusplusbattery.data.model.HistoryInfo
 import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
 
-class HistoryInfoRepository (application: Application) {
+class HistoryInfoRepository @Inject constructor (
+    application: Application
+) {
     private var historyInfoDao: HistoryInfoDao =
         HistoryInfoDatabase.Companion.getDatabase(application).historyInfoDao()
     val allHistoryInfos: Flow<List<HistoryInfo>> = historyInfoDao.getAllHistoryInfos()

--- a/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/PrefsRepository.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/data/repository/PrefsRepository.kt
@@ -26,11 +26,15 @@ import com.dijia1124.plusplusbattery.data.util.SHOW_SWITCH_ON_DASHBOARD
 import com.dijia1124.plusplusbattery.data.util.IS_CELSIUS
 import com.dijia1124.plusplusbattery.data.util.dataStore
 import com.dijia1124.plusplusbattery.service.DailyHistoryWorker
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.util.concurrent.TimeUnit
+import javax.inject.Inject
 
-class PrefsRepository(context: Context) {
+class PrefsRepository @Inject constructor (
+    @ApplicationContext context: Context
+) {
 
     private val dataStore = context.dataStore
 

--- a/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryInfoViewModel.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryInfoViewModel.kt
@@ -12,21 +12,25 @@ import com.dijia1124.plusplusbattery.data.repository.BatteryInfoRepository
 import com.dijia1124.plusplusbattery.data.repository.HistoryInfoRepository
 import com.dijia1124.plusplusbattery.data.repository.PrefsRepository
 import com.dijia1124.plusplusbattery.data.util.saveCycleCountToHistory
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
-class BatteryInfoViewModel(application: Application,
-                           private val batteryInfoRepository: BatteryInfoRepository = BatteryInfoRepository(
-                               application
-                           ),
-                           private val prefsRepo: PrefsRepository = PrefsRepository(application),
-                           private val historyInfoRepository: HistoryInfoRepository = HistoryInfoRepository(
-                               application
-                           )
+@HiltViewModel
+class BatteryInfoViewModel @Inject constructor(
+    application: Application,
+    private val batteryInfoRepository: BatteryInfoRepository = BatteryInfoRepository(
+        application
+    ),
+    private val prefsRepo: PrefsRepository = PrefsRepository(application),
+    private val historyInfoRepository: HistoryInfoRepository = HistoryInfoRepository(
+        application
+    )
 ) : AndroidViewModel(application) {
     private val context = application.applicationContext
 

--- a/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryLogViewModel.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryLogViewModel.kt
@@ -7,20 +7,22 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.dijia1124.plusplusbattery.data.model.DeviceInfo
 import com.dijia1124.plusplusbattery.data.repository.BatteryLogRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-
-class BatteryLogViewModel(
+@HiltViewModel
+class BatteryLogViewModel @Inject constructor(
     application: Application,
-    private val repo: BatteryLogRepository = BatteryLogRepository(),
-    private val refreshIntervalMs: Long = 1000L
+    private val repo: BatteryLogRepository = BatteryLogRepository()
 ) : AndroidViewModel(application) {
 
+    private val refreshIntervalMs: Long = 1000L
     private val _deviceInfo = MutableStateFlow(
         DeviceInfo(
             Build.MANUFACTURER ?: "Unknown",

--- a/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryMonitorSettingsViewModel.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/vm/BatteryMonitorSettingsViewModel.kt
@@ -10,6 +10,7 @@ import com.dijia1124.plusplusbattery.data.repository.BatteryInfoRepository
 import com.dijia1124.plusplusbattery.data.repository.PrefsRepository
 import com.dijia1124.plusplusbattery.service.BatteryMonitorService
 import com.dijia1124.plusplusbattery.service.FloatingWindowService
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -17,8 +18,10 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class BatteryMonitorSettingsViewModel(
+@HiltViewModel
+class BatteryMonitorSettingsViewModel @Inject constructor(
     application: Application,
     private val batteryRepo: BatteryInfoRepository = BatteryInfoRepository(application),
     private val prefsRepo: PrefsRepository = PrefsRepository(application)

--- a/app/src/main/java/com/dijia1124/plusplusbattery/vm/FloatingWindowSettingsViewModel.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/vm/FloatingWindowSettingsViewModel.kt
@@ -4,11 +4,16 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.dijia1124.plusplusbattery.data.repository.PrefsRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class FloatingWindowSettingsViewModel(application: Application) : AndroidViewModel(application) {
+@HiltViewModel
+class FloatingWindowSettingsViewModel @Inject constructor(
+    application: Application
+) : AndroidViewModel(application) {
 
     private val prefsRepository = PrefsRepository(application)
 

--- a/app/src/main/java/com/dijia1124/plusplusbattery/vm/HistoryInfoViewModel.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/vm/HistoryInfoViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.dijia1124.plusplusbattery.data.model.HistoryInfo
 import com.dijia1124.plusplusbattery.data.repository.HistoryInfoRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
@@ -16,8 +17,12 @@ import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import javax.inject.Inject
 
-class HistoryInfoViewModel(application: Application) : AndroidViewModel(application) {
+@HiltViewModel
+class HistoryInfoViewModel @Inject constructor(
+    application: Application
+) : AndroidViewModel(application) {
     private val cRepository: HistoryInfoRepository
     init{
         cRepository = HistoryInfoRepository(application)

--- a/app/src/main/java/com/dijia1124/plusplusbattery/vm/SettingsViewModel.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/vm/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.dijia1124.plusplusbattery.data.repository.PrefsRepository
 import com.topjohnwu.superuser.Shell
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -13,8 +14,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import javax.inject.Inject
 
-class SettingsViewModel(application: Application) : AndroidViewModel(application) {
+@HiltViewModel
+class SettingsViewModel @Inject constructor(
+    application: Application
+) : AndroidViewModel(application) {
 
     private val prefs = PrefsRepository(application)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.hilt) apply false
     id("org.sonarqube") version "6.3.1.5724"
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ roomCompiler = "2.7.2"
 roomRuntime = "2.7.2"
 ksp = "2.2.0-2.0.2"
 work = "2.10.4"
+hilt = "2.57.2"
 
 [libraries]
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "material3" }
@@ -49,6 +50,8 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
+hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -56,3 +59,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp"}
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }


### PR DESCRIPTION
This pull request integrates Dagger Hilt into the project to handle dependency injection, replacing the manual ViewModelProvider.Factory implementation. This refactor simplifies dependency management and reduces boilerplate code in the UI layer.