### PR TITLE
feat(ui): update description in battery multiplier dialog

### DIFF
--- a/app/src/main/java/com/dijia1124/plusplusbattery/ui/screen/Dashboard.kt
+++ b/app/src/main/java/com/dijia1124/plusplusbattery/ui/screen/Dashboard.kt
@@ -544,12 +544,15 @@ fun DashBoardContent(hasRoot: Boolean, batteryInfoViewModel: BatteryInfoViewMode
             onDismissRequest = { showMultiplierDialog = false },
             title = { Text(stringResource(R.string.calibrate_via_multiplier)) },
             text = {
-                MultiplierSelector(
-                    isMultiply = isMultiply,
-                    onMultiplyChange = { batteryInfoViewModel.setMultiplierPrefs(it, selectedMagnitude) },
-                    selectedMagnitude = selectedMagnitude,
-                    onMagnitudeChange = { batteryInfoViewModel.setMultiplierPrefs(isMultiply, it) }
-                )
+                Column (modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    Text(stringResource(R.string.battery_current_info))
+                    MultiplierSelector(
+                        isMultiply = isMultiply,
+                        onMultiplyChange = { batteryInfoViewModel.setMultiplierPrefs(it, selectedMagnitude) },
+                        selectedMagnitude = selectedMagnitude,
+                        onMagnitudeChange = { batteryInfoViewModel.setMultiplierPrefs(isMultiply, it) }
+                    )
+                }
             },
             confirmButton = {
                 Button(onClick = { showMultiplierDialog = false }) {

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -165,4 +165,5 @@
     <string name="other">其他</string>
     <string name="text">文字</string>
     <string name="interaction">互動</string>
+    <string name="battery_current_info">預設情況下，本應用程式將系統回報的數值視為 mA。但部分裝置可能使用 uA 或其他單位。若讀數不準確，請在此進行調整。</string>
 </resources>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -164,4 +164,5 @@
     <string name="other">其他</string>
     <string name="text">文本</string>
     <string name="interaction">交互</string>
+    <string name="battery_current_info">默认情况下，本应用将系统上报的数值视为 mA。但部分设备可能使用 uA 或其他单位。若读数不准确，请在此进行调整。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,4 +165,5 @@
     <string name="other">Other</string>
     <string name="text">Text</string>
     <string name="interaction">Interaction</string>
+    <string name="battery_current_info">System values are treated as mA by default. However, some devices report in uA or other units. Please adjust the setting here if your readings appear incorrect.</string>
 </resources>


### PR DESCRIPTION
This PR updates the battery multiplier dialog in the Dashboard to provide clearer guidance for users.


  Changes:
   - Added a descriptive text (battery_current_info) to the battery multiplier dialog to explain that system values are treated as mA by default and may require adjustment for devices reporting in different units (e.g., uA).
   - Wrapped the dialog content in a scrollable Column to ensure readability on various screen sizes.
   - Included localized strings for English, Simplified Chinese, and Traditional Chinese.
